### PR TITLE
Further improvements to the Point interface

### DIFF
--- a/base/point.h
+++ b/base/point.h
@@ -25,12 +25,18 @@ class Point {
    * \brief Standard destructor.
    */
   virtual ~Point();
-  /** General accessor method for the underlying data.
+
+  /** General accessor method for each feature of the underlying data.
    * \param feature_id The coordinate of interest. Indexing is implementation
    * specific.
    * \return The value of the coordinate specified in the input.
    */
   virtual double GetFeatureValue(unsigned feature_id) const = 0;
+
+  /** General accessor method for the label of the underlying data.
+   * \return The label of the object.
+   */
+  virtual double GetLabel() const = 0;
 
   /**
    * \brief Builds a `std::string` representation of the object.

--- a/tree/BUILD
+++ b/tree/BUILD
@@ -1,0 +1,8 @@
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+  name = "criterion",
+  hdrs = ["criterion.h"],
+  linkopts = ["-lm"],
+)
+


### PR DESCRIPTION
I noticed that our `base::Point` interface didn't have any accessor for the object's label / relevance / ground truth. @luizfgoncalves, could you please review it?
